### PR TITLE
falcon: init: Update/optimize setting properties

### DIFF
--- a/init/init_falcon.c
+++ b/init/init_falcon.c
@@ -63,24 +63,24 @@ void init_msm_properties(unsigned long msm_id, unsigned long msm_ver, char *boar
     fp = popen("/system/bin/blkid /dev/block/platform/msm_sdcc.1/by-name/userdata | /system/xbin/cut -d ' ' -f3", "r");
     fgets(fstype, sizeof(fstype), fp);
     pclose(fp);
+
+    property_set("ro.product.model", "Moto G");
     if (ISMATCH(radio, "0x1")) {
         if (strstr(fstype, "ext4")) {
             /* xt1032 GPE */
             property_set("ro.product.device", "falcon_gpe");
-            property_set("ro.product.model", "Moto G");
             property_set("ro.build.description", "falcon_gpe-user 5.0.1 LRX21Z.M002 15 release-keys");
             property_set("ro.build.fingerprint", "motorola/falcon_gpe/falcon_umts:5.0.1/LRX21Z.M002/15:user/release-keys");
-            property_set("ro.build.product", "falcon");
+            property_set("ro.build.product", "falcon_gpe");
             property_set("ro.mot.build.customerid", "retusa_glb");
             property_set("ro.telephony.default_network", "0");
             property_set("persist.radio.multisim.config", "");
         } else {
             /* xt1032 */
             property_set("ro.product.device", "falcon_umts");
-            property_set("ro.product.model", "Moto G");
             property_set("ro.build.description", "falcon_retgb-user 4.4.4 KXB21.14-L1.40 36 release-keys");
             property_set("ro.build.fingerprint", "motorola/falcon_retgb/falcon_umts:4.4.4/KXB21.14-L1.40/36:user/release-keys");
-            property_set("ro.build.product", "falcon");
+            property_set("ro.build.product", "falcon_umts");
             property_set("ro.mot.build.customerid", "RTGB");
             property_set("ro.telephony.default_network", "0");
             property_set("persist.radio.multisim.config", "");
@@ -91,10 +91,9 @@ void init_msm_properties(unsigned long msm_id, unsigned long msm_ver, char *boar
         if (ISMATCH(cdma_variant, "verizon")) {
             /* xt1028 */
             property_set("ro.product.device", "falcon_cdma");
-            property_set("ro.product.model", "Moto G");
             property_set("ro.build.description", "falcon_verizon-user 4.3 14.10.0Q3.X-84-14 16 release-keys");
             property_set("ro.build.fingerprint", "motorola/falcon_verizon/falcon_cdma:4.3/14.10.0Q3.X-84-14/16:user/release-keys");
-            property_set("ro.build.product", "falcon");
+            property_set("ro.build.product", "falcon_cdma");
             property_set("persist.radio.multisim.config", "");
             property_set("ro.mot.build.customerid", "verizon");
             property_set("ro.cdma.home.operator.alpha", "Verizon");
@@ -105,10 +104,9 @@ void init_msm_properties(unsigned long msm_id, unsigned long msm_ver, char *boar
         } else {
             /* xt1031 */
             property_set("ro.product.device", "falcon_cdma");
-            property_set("ro.product.model", "Moto G");
             property_set("ro.build.description", "falcon_boost-user 4.4.2 KXB20.9-1.10-1.18 18 release-keys");
             property_set("ro.build.fingerprint", "motorola/falcon_boost/falcon_cdma:4.4.2/KXB20.9-1.10-1.18/18:user/release-keys");
-            property_set("ro.build.product", "falcon");
+            property_set("ro.build.product", "falcon_cdma");
             property_set("persist.radio.multisim.config", "");
             property_set("ro.mot.build.customerid", "sprint");
             property_set("ro.cdma.home.operator.alpha", "Boost Mobile");
@@ -127,10 +125,9 @@ void init_msm_properties(unsigned long msm_id, unsigned long msm_ver, char *boar
     } else if (ISMATCH(radio, "0x5")) {
         /* xt1033 */
         property_set("ro.product.device", "falcon_umtsds");
-        property_set("ro.product.model", "Moto G");
         property_set("ro.build.description", "falcon_retbr_ds-user 5.0 LXB22.46-16 16 release-keys");
         property_set("ro.build.fingerprint", "motorola/falcon_retbr_ds/falcon_umtsds:5.0/LXB22.46-16/16:user/release-keys");
-        property_set("ro.build.product", "falcon");
+        property_set("ro.build.product", "falcon_umtsds");
         property_set("ro.mot.build.customerid", "RETBR");
         property_set("ro.telephony.default_network", "0");
         property_set("persist.radio.multisim.config", "dsds");
@@ -139,14 +136,14 @@ void init_msm_properties(unsigned long msm_id, unsigned long msm_ver, char *boar
     } else if (ISMATCH(radio, "0x6")) {
         /* xt1034 */
         property_set("ro.product.device", "falcon_umts");
-        property_set("ro.product.model", "Moto G");
         property_set("ro.build.description", "falcon_retuaws-user 4.4.3 KXB21.14-L1.32 30 release-keys");
         property_set("ro.build.fingerprint", "motorola/falcon_retuaws/falcon_umts:4.4.3/KXB21.14-L1.32/30:user/release-keys");
-        property_set("ro.build.product", "falcon");
+        property_set("ro.build.product", "falcon_umts");
         property_set("ro.mot.build.customerid", "retusa_aws");
         property_set("ro.telephony.default_network", "0");
         property_set("persist.radio.multisim.config", "");
     }
+
     property_get("ro.product.device", device);
     strlcpy(devicename, device, sizeof(devicename));
     INFO("Found radio id: %s data %s setting build properties for %s device\n", radio, fstype, devicename);


### PR DESCRIPTION
* ro.product.model is always the same on all variants
* ro.build.product should be the same as ro.product.device

Change-Id: I2ce54dea4502af02fffa8861568f82da71949e05